### PR TITLE
Fix active tab persistence in dashboard

### DIFF
--- a/scripts/dashboard.php
+++ b/scripts/dashboard.php
@@ -239,5 +239,24 @@ $vehiculos = cargarVehiculos();
             </table>
         </div>
     </div>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        if (location.hash) {
+            var triggerEl = document.querySelector('button[data-bs-target="' + location.hash + '"]');
+            if (triggerEl) {
+                bootstrap.Tab.getOrCreateInstance(triggerEl).show();
+            }
+        }
+
+        var tabButtons = document.querySelectorAll('button[data-bs-toggle="tab"]');
+        tabButtons.forEach(function (button) {
+            button.addEventListener('shown.bs.tab', function (event) {
+                var target = event.target.getAttribute('data-bs-target');
+                history.replaceState(null, '', target);
+            });
+        });
+    });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep the current tab active when the dashboard reloads

## Testing
- `node -e "require('./script.js')"` *(fails: document is not defined)*
- `php -l scripts/dashboard.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ac308fa0832abc4c1a0b2845cc2b